### PR TITLE
Allow assign to overwrite existing components.

### DIFF
--- a/entityx/Entity.h
+++ b/entityx/Entity.h
@@ -574,7 +574,8 @@ class EntityManager : entityx::help::NonCopyable {
   ComponentHandle<C> assign(Entity::Id id, Args && ... args) {
     assert_valid(id);
     const BaseComponent::Family family = C::family();
-    assert(!entity_component_mask_[id.index()].test(family));
+    // We want to be able to assign components and replace existing ones.
+//    assert(!entity_component_mask_[id.index()].test(family));
 
     // Placement new into the component pool.
     Pool<C> *pool = accomodate_component<C>();


### PR DESCRIPTION
Not sure if this introduces bugs elsewhere, but it is much nicer
than doing the if exists update otherwise assign dance in client code.
