### PR TITLE
Revert "Allow assign to overwrite existing components."

### DIFF
--- a/entityx/Entity.h
+++ b/entityx/Entity.h
@@ -574,8 +574,7 @@ class EntityManager : entityx::help::NonCopyable {
   ComponentHandle<C> assign(Entity::Id id, Args && ... args) {
     assert_valid(id);
     const BaseComponent::Family family = C::family();
-    // We want to be able to assign components and replace existing ones.
-//    assert(!entity_component_mask_[id.index()].test(family));
+    assert(!entity_component_mask_[id.index()].test(family));
 
     // Placement new into the component pool.
     Pool<C> *pool = accomodate_component<C>();


### PR DESCRIPTION
Reverts sansumbrella/entityx#1

Just work around it by unpacking components and allowing the assertions to catch mistakes there.
